### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Limit matrix platforms in publish.yml to ubuntu-latest only